### PR TITLE
Use lower bound for matplotlib requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 dwave-ocean-sdk>=3.3.0
-matplotlib==3.5.1
+matplotlib>=3.3.4


### PR DESCRIPTION
- fixes failing py3.6 tests